### PR TITLE
Reset pasted flag on new song

### DIFF
--- a/userscripts/amqCoopPaste.user.js
+++ b/userscripts/amqCoopPaste.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name        	AMQ Co-op Autopaste
 // @namespace   	https://github.com/ayyu/
-// @version     	2.4.4
+// @version     	2.4.5
 // @description 	Automatically pastes your submitted answer to chat. Also copies other people's submitted answers.
 // @author      	ayyu
 // @match       	https://animemusicquiz.com/*
@@ -92,7 +92,11 @@
     new Listener("quiz answer", answerHandler).bindListener();
 
     // clear last answer upon new song
-    new Listener("answer results", () => lastAnswer = "").bindListener();
+    // reset the pasted flag back to false to allow someone else to publish answer on a new song.
+    new Listener("answer results", () =>{
+        lastAnswer = "";
+        pasted = false;
+    }).bindListener();
 
     // enter answers that are pasted
     new Listener("game chat message", messageHandler).bindListener();


### PR DESCRIPTION
Previously, only the first person to submit their answer was able to trigger the copy-paste to everyone's answer box for the entire duration of the game. 

With the "pasted" flag reset on a new song, the first person to submit their answer will only have control of everyone else's answer box over the duration of one song. 